### PR TITLE
Set HOME environment variable if user extension is active

### DIFF
--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -58,7 +58,7 @@ def detect_os(image_name, output_callback=None):
             output_callback('Failed to build detector image')
         return None
 
-    cmd="docker run -it --rm %s" % image_id
+    cmd="docker run -it --rm -u root %s" % image_id
     if output_callback:
         output_callback("running, ", cmd)
     p = pexpect.spawn(cmd)

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -26,3 +26,5 @@ USER @(name)
 @[else]@
 # Detected user is root, which already exists so not creating new user.
 @[end if]@
+# Set HOME environment variable
+ENV HOME "@(dir)"


### PR DESCRIPTION
`HOME` might still point to the original home directory of another user that exists in the image.

With `--user`, `HOME` should point to the newly created home directory (or the mounted home directory in combination with `--home`).