### PR TITLE
Pass-through arguments to docker run and support --volume/-v …

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [sdist_dsc]
-debian-version: 1intermodalics
+debian-version: 2intermodalics

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [sdist_dsc]
-debian-version: 2intermodalics
+epoch: 1
+debian-version: 3intermodalics

--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -36,7 +36,7 @@ def main():
     parser.add_argument('--noexecute', action='store_true', help='Deprecated')
     parser.add_argument('--nocache', action='store_true')
     parser.add_argument('--pull', action='store_true')
-    parser.add_argument('-v', '--version', action='version',
+    parser.add_argument('--version', action='version',
         version='%(prog)s ' + get_rocker_version())
 
     try:
@@ -47,7 +47,7 @@ def main():
         # Catch errors if docker is missing or inaccessible.
         parser.error("DependencyMissing encountered: %s" % ex)
 
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
     args_dict = vars(args)
 
     if args.noexecute:
@@ -69,7 +69,7 @@ def main():
         return exit_code
     # Convert command into string
     args.command = ' '.join(args.command)
-    return dig.run(**args_dict)
+    return dig.run(**args_dict, unknown_args=unknown_args)
 
 
 def detect_image_os():

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -82,7 +82,7 @@ class RockerExtension(object):
         """ Returns true if the arguments indicate that this extension should be activated otherwise false.
         The default implementation looks for the extension name has any value.
         It is recommended to override this unless it's just a flag to enable the plugin."""
-        return True if cli_args.get(cls.get_name()) else False
+        return cli_args.get(cls.get_name()) is not None
 
     @staticmethod
     def register_arguments(parser, defaults={}):
@@ -239,7 +239,7 @@ class DockerImageGenerator(object):
                 print("Docker build failed\n", ex)
                 return 1
 
-    def run(self, command='', **kwargs):
+    def run(self, command='', unknown_args=[], **kwargs):
         if not self.built:
             print("Cannot run if build has not passed.")
             return 1
@@ -254,6 +254,8 @@ class DockerImageGenerator(object):
 
         for e in self.active_extensions:
             docker_args += e.get_docker_args(self.cliargs)
+        #docker_args += shlex.join(unknown_args)
+        docker_args += ' '.join([shlex.quote(arg) for arg in unknown_args])
 
         image = self.image_id
         operating_mode = kwargs.get('mode')

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -239,7 +239,7 @@ class DockerImageGenerator(object):
                 print("Docker build failed\n", ex)
                 return 1
 
-    def run(self, command='', unknown_args=[], **kwargs):
+    def run(self, command='', additional_args=[], **kwargs):
         if not self.built:
             print("Cannot run if build has not passed.")
             return 1
@@ -254,8 +254,9 @@ class DockerImageGenerator(object):
 
         for e in self.active_extensions:
             docker_args += e.get_docker_args(self.cliargs)
-        #docker_args += shlex.join(unknown_args)
-        docker_args += ' '.join([shlex.quote(arg) for arg in unknown_args])
+        if additional_args:
+            #docker_args += ' ' + shlex.join(additional_args)
+            docker_args += ' ' + ' '.join([shlex.quote(arg) for arg in additional_args])
 
         image = self.image_id
         operating_mode = kwargs.get('mode')

--- a/src/rocker/git_extension.py
+++ b/src/rocker/git_extension.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
+import argparse
 import os
 from rocker.extensions import RockerExtension
 
@@ -57,5 +57,5 @@ class Git(RockerExtension):
     def register_arguments(parser, defaults={}):
         parser.add_argument('--git',
             action='store_true',
-            default=defaults.get(Git.get_name(), None),
+            default=defaults.get(Git.get_name(), argparse.SUPPRESS),
             help="Use the global Git settings from the host (/etc/gitconfig and ~/.gitconfig)")

--- a/src/rocker/mount_extension.py
+++ b/src/rocker/mount_extension.py
@@ -57,7 +57,7 @@ class Mount(RockerExtension):
             elems = mount.split(',')
             if len(elems) == 1:
                 if ':' in elems[0]:
-                    volumes.append(elems)
+                    volumes.append(elems[0])
                 else:
                     host_dir = os.path.abspath(elems[0])
                     args.append('-v {0}:{0}'.format(host_dir))

--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import grp
 import os
 import em
@@ -72,7 +73,7 @@ class X11(RockerExtension):
     def register_arguments(parser, defaults={}):
         parser.add_argument(name_to_argument(X11.get_name()),
             action='store_true',
-            default=defaults.get(X11.get_name(), None),
+            default=defaults.get(X11.get_name(), argparse.SUPPRESS),
             help="Enable x11")
 
 
@@ -130,7 +131,7 @@ class Nvidia(RockerExtension):
     def register_arguments(parser, defaults={}):
         parser.add_argument(name_to_argument(Nvidia.get_name()),
             action='store_true',
-            default=defaults.get(Nvidia.get_name(), None),
+            default=defaults.get(Nvidia.get_name(), argparse.SUPPRESS),
             help="Enable nvidia")
 
 

--- a/src/rocker/ssh_extension.py
+++ b/src/rocker/ssh_extension.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
+import argparse
 import os
 import shlex
 
@@ -49,5 +49,5 @@ class Ssh(RockerExtension):
     def register_arguments(parser, defaults={}):
         parser.add_argument('--ssh',
             action='store_true',
-            default=defaults.get(Ssh.get_name(), None),
+            default=defaults.get(Ssh.get_name(), argparse.SUPPRESS),
             help="Forward SSH agent into the container")

--- a/src/rocker/ssh_server_extension.py
+++ b/src/rocker/ssh_server_extension.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import em
 import pkgutil
 
@@ -40,5 +41,5 @@ class SshServer(RockerExtension):
     def register_arguments(parser, defaults={}):
         parser.add_argument(name_to_argument(SshServer.get_name()),
             action='store_true',
-            default=defaults.get(SshServer.get_name(), False),
+            default=defaults.get(SshServer.get_name(), argparse.SUPPRESS),
             help="Installs and configures an SSH server inside the container")

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [rocker]
 Epoch: 1
-Debian-Version: 0intermodalics
+Debian-Version: 2intermodalics
 No-Python2:
 Depends3: python3-docker, python3-empy, python3-pexpect, python3-packaging
 Conflicts3: python-rocker

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,5 @@
 [rocker]
-Epoch: 1
-Debian-Version: 2intermodalics
+Debian-Version: 100
 No-Python2:
 Depends3: python3-docker, python3-empy, python3-pexpect, python3-packaging
 Conflicts3: python-rocker


### PR DESCRIPTION
… for the mount extension with backwards compatibility.

The overall goal is that the rocker command-line usage is closer to that of docker run and most arguments just work. Actually that makes some extensions like to pass environment variables obsolete.

However, it is not straight-forward because rocker cannot know which flags have one or more optional arguments and which positional argument is the image. That is why one has to split rocker and docker arguments by `--`, and ideally also the image name and optional command by another `--` argument:
```sh
$ rocker --help
usage: rocker [rocker arguments] [-- [docker run arguments]] -- image [command [command ...]]

A tool for running docker with extra options

positional arguments:
  image
  command

optional arguments:
...
```

Not sure whether there is a way to tell [argparse](https://docs.python.org/3/library/argparse.html) to stop searching for `-*` arguments after the first positional arguments, and consider all the rest as part of the command. At the moment this does not work, with or without this patch:
```sh
$ rocker ubuntu:focal bash -x
usage: rocker [rocker arguments] [-- [docker run arguments]] -- image [command [command ...]]
rocker: error: unrecognized arguments: -x
```

But [argparse does support the pseudo-argument `--`](https://docs.python.org/3/library/argparse.html#arguments-containing) which tells `parse_args()` that everything after that is a positional argument. So this works:
```sh
$ rocker -- ubuntu:focal bash -x
```

New version pushed to our internal repos as version `1:0.2.3-2intermodalics`.